### PR TITLE
Actions Fix: Use a PR to do code styling

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -4,10 +4,6 @@ on:
   push:
     paths:
       - '**.php'
-    branches:
-      - '**'
-    branches-ignore:
-      - "main"
 
 permissions:
   contents: write
@@ -25,7 +21,13 @@ jobs:
       - name: Fix PHP code style issues
         uses: aglipanci/laravel-pint-action@2.5
 
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
         with:
-          commit_message: Fix styling
+          commit-message: Fix styling
+          branch: php-style-fixes
+          title: Fix PHP Code Styling
+          body: This PR fixes PHP code style issues.
+          labels: code-style
+          auto-merge: true
+          delete-branch: true

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -5,8 +5,6 @@ on:
     paths:
       - '**.php'
       - 'phpstan.neon.dist'
-    branches: ["**"]
-    branches-ignore: ["main"]
 
 jobs:
   phpstan:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/coolsam/nested-comments.svg?style=flat-square)](https://packagist.org/packages/coolsam/nested-comments)
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/coolsam726/nested-comments/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/coolsam726/nested-comments/actions?query=workflow%3Arun-tests+branch%3Amain)
-[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/coolsam726/nested-comments/fix-php-code-styling.yml?branch=features&label=code%20style&style=flat-square)](https://github.com/coolsam726/nested-comments/actions?query=workflow%3A"Fix+PHP+Code+Styling"+branch%3Afeatures)
+[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/coolsam726/nested-comments/fix-php-code-styling.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/coolsam726/nested-comments/actions?query=workflow%3A"Fix+PHP+Code+Styling"+branch%3Amain)
+[![GitHub PHPStan Action Status](https://img.shields.io/github/actions/workflow/status/coolsam726/nested-comments/phpstan.yml?branch=main&label=phpstan&style=flat-square)](https://github.com/coolsam726/nested-comments/actions?query=workflow%3APHPStan+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/coolsam/nested-comments.svg?style=flat-square)](https://packagist.org/packages/coolsam/nested-comments)
 
 


### PR DESCRIPTION
- Use a PR instead of direct commit for code style fixes
- Added a PHPStan badge
- Revert: use main branch for phpstan and code styling actions